### PR TITLE
fix: prevent auth login enumeration and restore env example

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -11,7 +11,7 @@ SERVICE_API_PREFIX=https://your-domain.com/api
 
 # ==================== 前端构建配置 ====================
 # UI 容器构建时注入的 API 前缀
-VITE_API_PREFIX=https://127.0.0.1:5001
+VITE_API_PREFIX=http://127.0.0.1:5001
 
 # ==================== JWT 加密密钥 ====================
 # 生成方法: openssl rand -hex 32

--- a/api/internal/service/account_service.py
+++ b/api/internal/service/account_service.py
@@ -1045,14 +1045,15 @@ class AccountService(BaseService):
     def password_login(self, email: str, password: str) -> dict[str, Any]:
         """根据传递的密码 + 邮箱登录特定的账号"""
         normalized_email = self._normalize_email(email)
+        generic_error_message = "账号不存在或者密码错误"
 
         # 1.根据传递的邮箱查询账号是否存在
         account = self.get_account_by_email(normalized_email)
         if not account:
-            raise FailException("账号不存在")
+            raise FailException(generic_error_message)
 
         if not account.is_password_set:
-            raise FailException(self._build_oauth_only_login_message(account))
+            raise FailException(generic_error_message)
 
         # 2.校验账号密码是否正确
         if not compare_password(
@@ -1060,7 +1061,7 @@ class AccountService(BaseService):
             account.password,
             account.password_salt
         ):
-            raise FailException("密码错误")
+            raise FailException(generic_error_message)
 
         # 3.根据登录风险返回授权凭证或二次验证挑战
         return self.begin_login(account)

--- a/api/test/internal/service/test_account_service.py
+++ b/api/test/internal/service/test_account_service.py
@@ -815,7 +815,7 @@ class TestAccountService:
             with pytest.raises(FailException) as exc_info:
                 service.password_login("demo@example.com", "new-pwd")
 
-        assert "该账号尚未设置密码，请使用Google登录" in str(exc_info.value)
+        assert "账号不存在或者密码错误" in str(exc_info.value)
 
     def test_password_login_should_return_token_and_update_login_info(self, monkeypatch):
         redis_stub = _RedisStub()
@@ -985,7 +985,7 @@ class TestAccountService:
             with pytest.raises(FailException) as exc_info:
                 service.password_login(email, "pwd")
 
-        assert "账号不存在" in str(exc_info.value)
+        assert "账号不存在或者密码错误" in str(exc_info.value)
         assert len(redis_stub.setex_calls) == 0
 
     def test_is_login_locked_should_fallback_to_false_when_redis_unavailable(self, monkeypatch):
@@ -1052,7 +1052,7 @@ class TestAccountService:
             with pytest.raises(FailException) as exc_info:
                 service.password_login(email, "wrong")
 
-        assert "密码错误" in str(exc_info.value)
+        assert "账号不存在或者密码错误" in str(exc_info.value)
 
     def test_send_reset_code_should_return_silently_when_email_not_registered(self, monkeypatch):
         service = self._build_service()


### PR DESCRIPTION
### Summary
- restore `.env.example` local API prefix to HTTP
- collapse password login failures to a generic public-facing error message
- update account service tests accordingly

### Validation
- account service tests passed
- backend full test suite passed: 1558 passed