### PR TITLE
Normalize provider pricing to RMB

### DIFF
--- a/api/internal/core/language_model/providers/deepseek/deepseek-chat.yaml
+++ b/api/internal/core/language_model/providers/deepseek/deepseek-chat.yaml
@@ -2,37 +2,37 @@ model: deepseek-chat
 label: deepseek-chat
 model_type: chat
 features:
-  - tool_call
-  - agent_thought
+- tool_call
+- agent_thought
 context_window: 64000
 max_output_tokens: 8000
 attributes:
   model: deepseek-chat
 parameters:
-  - name: temperature
-    use_template: temperature
-    default: 1
-  - name: top_p
-    use_template: top_p
-    default: 1
-  - name: presence_penalty
-    use_template: presence_penalty
-    default: 0.0
-  - name: frequency_penalty
-    use_template: frequency_penalty
-    default: 0.0
-  - name: max_tokens
-    use_template: max_tokens
-    default: 8000
-    max: 8000
+- name: temperature
+  use_template: temperature
+  default: 1
+- name: top_p
+  use_template: top_p
+  default: 1
+- name: presence_penalty
+  use_template: presence_penalty
+  default: 0.0
+- name: frequency_penalty
+  use_template: frequency_penalty
+  default: 0.0
+- name: max_tokens
+  use_template: max_tokens
+  default: 8000
+  max: 8000
 metadata:
   pricing:
-    input: 0.00027
-    output: 0.0011
+    input: 0.001846
+    output: 0.007522
     unit: 0.001
-    currency: USD
+    currency: RMB
   pricing_cache_hit:
-    input: 0.00007
-    output: 0.0011
+    input: 0.000479
+    output: 0.007522
     unit: 0.001
-    currency: USD
+    currency: RMB

--- a/api/internal/core/language_model/providers/deepseek/deepseek-reasoner.yaml
+++ b/api/internal/core/language_model/providers/deepseek/deepseek-reasoner.yaml
@@ -2,24 +2,24 @@ model: deepseek-reasoner
 label: deepseek-reasoner
 model_type: chat
 features:
-  - agent_thought
+- agent_thought
 context_window: 128000
 max_output_tokens: 64000
 attributes:
   model: deepseek-reasoner
 parameters:
-  - name: max_tokens
-    use_template: max_tokens
-    default: 8192
-    max: 64000
+- name: max_tokens
+  use_template: max_tokens
+  default: 8192
+  max: 64000
 metadata:
   pricing:
-    input: 0.00055
-    output: 0.00219
+    input: 0.003761
+    output: 0.014977
     unit: 0.001
-    currency: USD
+    currency: RMB
   pricing_cache_hit:
-    input: 0.00014
-    output: 0.00219
+    input: 0.000957
+    output: 0.014977
     unit: 0.001
-    currency: USD
+    currency: RMB

--- a/api/internal/core/language_model/providers/deepseek/deepseek-v4-flash.yaml
+++ b/api/internal/core/language_model/providers/deepseek/deepseek-v4-flash.yaml
@@ -2,37 +2,37 @@ model: deepseek-v4-flash
 label: deepseek-v4-flash
 model_type: chat
 features:
-  - tool_call
-  - agent_thought
+- tool_call
+- agent_thought
 context_window: 1000000
 max_output_tokens: 384000
 attributes:
   model: deepseek-v4-flash
 parameters:
-  - name: temperature
-    use_template: temperature
-    default: 1
-  - name: top_p
-    use_template: top_p
-    default: 1
-  - name: presence_penalty
-    use_template: presence_penalty
-    default: 0.0
-  - name: frequency_penalty
-    use_template: frequency_penalty
-    default: 0.0
-  - name: max_tokens
-    use_template: max_tokens
-    default: 8192
-    max: 384000
+- name: temperature
+  use_template: temperature
+  default: 1
+- name: top_p
+  use_template: top_p
+  default: 1
+- name: presence_penalty
+  use_template: presence_penalty
+  default: 0.0
+- name: frequency_penalty
+  use_template: frequency_penalty
+  default: 0.0
+- name: max_tokens
+  use_template: max_tokens
+  default: 8192
+  max: 384000
 metadata:
   pricing:
-    input: 0.00014
-    output: 0.00028
+    input: 0.000957
+    output: 0.001915
     unit: 0.001
-    currency: USD
+    currency: RMB
   pricing_cache_hit:
-    input: 0.000028
-    output: 0.00028
+    input: 0.000191
+    output: 0.001915
     unit: 0.001
-    currency: USD
+    currency: RMB

--- a/api/internal/core/language_model/providers/deepseek/deepseek-v4-pro.yaml
+++ b/api/internal/core/language_model/providers/deepseek/deepseek-v4-pro.yaml
@@ -2,37 +2,37 @@ model: deepseek-v4-pro
 label: deepseek-v4-pro
 model_type: chat
 features:
-  - tool_call
-  - agent_thought
+- tool_call
+- agent_thought
 context_window: 1000000
 max_output_tokens: 384000
 attributes:
   model: deepseek-v4-pro
 parameters:
-  - name: temperature
-    use_template: temperature
-    default: 1
-  - name: top_p
-    use_template: top_p
-    default: 1
-  - name: presence_penalty
-    use_template: presence_penalty
-    default: 0.0
-  - name: frequency_penalty
-    use_template: frequency_penalty
-    default: 0.0
-  - name: max_tokens
-    use_template: max_tokens
-    default: 8192
-    max: 384000
+- name: temperature
+  use_template: temperature
+  default: 1
+- name: top_p
+  use_template: top_p
+  default: 1
+- name: presence_penalty
+  use_template: presence_penalty
+  default: 0.0
+- name: frequency_penalty
+  use_template: frequency_penalty
+  default: 0.0
+- name: max_tokens
+  use_template: max_tokens
+  default: 8192
+  max: 384000
 metadata:
   pricing:
-    input: 0.000145
-    output: 0.00087
+    input: 0.000992
+    output: 0.00595
     unit: 0.001
-    currency: USD
+    currency: RMB
   pricing_cache_hit:
-    input: 0.00003625
-    output: 0.00087
+    input: 0.000248
+    output: 0.00595
     unit: 0.001
-    currency: USD
+    currency: RMB

--- a/api/internal/core/language_model/providers/google/gemini-2.5-flash-lite.yaml
+++ b/api/internal/core/language_model/providers/google/gemini-2.5-flash-lite.yaml
@@ -2,37 +2,37 @@ model: gemini-2.5-flash-lite
 label: gemini-2.5-flash-lite
 model_type: chat
 features:
-  - tool_call
-  - agent_thought
-  - image_input
+- tool_call
+- agent_thought
+- image_input
 context_window: 1048576
 max_output_tokens: 65536
 attributes:
   model: gemini-2.5-flash-lite
 parameters:
-  - name: temperature
-    use_template: temperature
-    default: 1
-  - name: top_p
-    use_template: top_p
-    default: 0.95
-  - name: top_k
-    label: Top K
-    type: int
-    help: 仅从最高概率的前K个候选中采样。
-    required: false
-    default: 64
-    min: 1
-    max: 64
-    precision: 0
-    options: []
-  - name: max_tokens
-    use_template: max_tokens
-    default: 8192
-    max: 65536
+- name: temperature
+  use_template: temperature
+  default: 1
+- name: top_p
+  use_template: top_p
+  default: 0.95
+- name: top_k
+  label: Top K
+  type: int
+  help: 仅从最高概率的前K个候选中采样。
+  required: false
+  default: 64
+  min: 1
+  max: 64
+  precision: 0
+  options: []
+- name: max_tokens
+  use_template: max_tokens
+  default: 8192
+  max: 65536
 metadata:
   pricing:
-    input: 0.0001
-    output: 0.0004
+    input: 0.000684
+    output: 0.002735
     unit: 0.001
-    currency: USD
+    currency: RMB

--- a/api/internal/core/language_model/providers/google/gemini-2.5-flash.yaml
+++ b/api/internal/core/language_model/providers/google/gemini-2.5-flash.yaml
@@ -2,37 +2,37 @@ model: gemini-2.5-flash
 label: gemini-2.5-flash
 model_type: chat
 features:
-  - tool_call
-  - agent_thought
-  - image_input
+- tool_call
+- agent_thought
+- image_input
 context_window: 1048576
 max_output_tokens: 65535
 attributes:
   model: gemini-2.5-flash
 parameters:
-  - name: temperature
-    use_template: temperature
-    default: 1
-  - name: top_p
-    use_template: top_p
-    default: 0.95
-  - name: top_k
-    label: Top K
-    type: int
-    help: 仅从最高概率的前K个候选中采样。
-    required: false
-    default: 64
-    min: 1
-    max: 64
-    precision: 0
-    options: []
-  - name: max_tokens
-    use_template: max_tokens
-    default: 8192
-    max: 65535
+- name: temperature
+  use_template: temperature
+  default: 1
+- name: top_p
+  use_template: top_p
+  default: 0.95
+- name: top_k
+  label: Top K
+  type: int
+  help: 仅从最高概率的前K个候选中采样。
+  required: false
+  default: 64
+  min: 1
+  max: 64
+  precision: 0
+  options: []
+- name: max_tokens
+  use_template: max_tokens
+  default: 8192
+  max: 65535
 metadata:
   pricing:
-    input: 0.0003
-    output: 0.0025
+    input: 0.002052
+    output: 0.017097
     unit: 0.001
-    currency: USD
+    currency: RMB

--- a/api/internal/core/language_model/providers/google/gemini-2.5-pro.yaml
+++ b/api/internal/core/language_model/providers/google/gemini-2.5-pro.yaml
@@ -2,42 +2,43 @@ model: gemini-2.5-pro
 label: gemini-2.5-pro
 model_type: chat
 features:
-  - tool_call
-  - agent_thought
-  - image_input
+- tool_call
+- agent_thought
+- image_input
 context_window: 1048576
 max_output_tokens: 65536
 attributes:
   model: gemini-2.5-pro
 parameters:
-  - name: temperature
-    use_template: temperature
-    default: 1
-  - name: top_p
-    use_template: top_p
-    default: 0.95
-  - name: top_k
-    label: Top K
-    type: int
-    help: 仅从最高概率的前K个候选中采样。
-    required: false
-    default: 64
-    min: 1
-    max: 64
-    precision: 0
-    options: []
-  - name: max_tokens
-    use_template: max_tokens
-    default: 8192
-    max: 65536
+- name: temperature
+  use_template: temperature
+  default: 1
+- name: top_p
+  use_template: top_p
+  default: 0.95
+- name: top_k
+  label: Top K
+  type: int
+  help: 仅从最高概率的前K个候选中采样。
+  required: false
+  default: 64
+  min: 1
+  max: 64
+  precision: 0
+  options: []
+- name: max_tokens
+  use_template: max_tokens
+  default: 8192
+  max: 65536
 metadata:
   pricing:
-    input: 0.00125
-    output: 0.01
+    input: 0.008548
+    output: 0.068386
     unit: 0.001
-    currency: USD
+    currency: RMB
   pricing_tiered:
     long_context:
-      input: 0.0025
-      output: 0.015
+      input: 0.017097
+      output: 0.102579
       threshold_tokens: 200000
+      currency: RMB

--- a/api/internal/core/language_model/providers/grok/grok-4.yaml
+++ b/api/internal/core/language_model/providers/grok/grok-4.yaml
@@ -2,39 +2,39 @@ model: grok-4
 label: grok-4
 model_type: chat
 features:
-  - tool_call
-  - agent_thought
-  - image_input
+- tool_call
+- agent_thought
+- image_input
 context_window: 256000
 max_output_tokens: 65536
 attributes:
   model: grok-4
 parameters:
-  - name: temperature
-    use_template: temperature
-    default: 0.7
-  - name: top_p
-    use_template: top_p
-    default: 1
-  - name: max_tokens
-    use_template: max_tokens
-    default: 8192
-    max: 65536
+- name: temperature
+  use_template: temperature
+  default: 0.7
+- name: top_p
+  use_template: top_p
+  default: 1
+- name: max_tokens
+  use_template: max_tokens
+  default: 8192
+  max: 65536
 metadata:
   pricing:
-    input: 0.003
-    output: 0.015
+    input: 0.020516
+    output: 0.102579
     unit: 0.001
-    currency: USD
+    currency: RMB
   pricing_long_context:
-    input: 0.006
-    output: 0.03
+    input: 0.041032
+    output: 0.205158
     threshold_tokens: 128000
     unit: 0.001
-    currency: USD
+    currency: RMB
   pricing_cache_hit:
-    input: 0.00075
-    output: 0.015
+    input: 0.005129
+    output: 0.102579
     unit: 0.001
-    currency: USD
+    currency: RMB
   pricing_source: docs_xai_models

--- a/api/internal/core/language_model/providers/openai/gpt-4o-mini.yaml
+++ b/api/internal/core/language_model/providers/openai/gpt-4o-mini.yaml
@@ -2,33 +2,33 @@ model: gpt-4o-mini
 label: gpt-4o-mini
 model_type: chat
 features:
-  - tool_call
-  - agent_thought
-  - image_input
+- tool_call
+- agent_thought
+- image_input
 context_window: 128000
 max_output_tokens: 16384
 attributes:
   model: gpt-4o-mini
 parameters:
-  - name: temperature
-    use_template: temperature
-  - name: top_p
-    use_template: top_p
-  - name: presence_penalty
-    use_template: presence_penalty
-  - name: frequency_penalty
-    use_template: frequency_penalty
-  - name: max_tokens
-    use_template: max_tokens
-    default: 4096
+- name: temperature
+  use_template: temperature
+- name: top_p
+  use_template: top_p
+- name: presence_penalty
+  use_template: presence_penalty
+- name: frequency_penalty
+  use_template: frequency_penalty
+- name: max_tokens
+  use_template: max_tokens
+  default: 4096
 metadata:
   pricing:
-    input: 0.00015
-    output: 0.0006
+    input: 0.001026
+    output: 0.004103
     unit: 0.001
-    currency: USD
+    currency: RMB
   pricing_cache_hit:
-    input: 0.000075
-    output: 0.0006
+    input: 0.000513
+    output: 0.004103
     unit: 0.001
-    currency: USD
+    currency: RMB

--- a/api/internal/core/language_model/providers/openai/gpt-4o.yaml
+++ b/api/internal/core/language_model/providers/openai/gpt-4o.yaml
@@ -2,33 +2,33 @@ model: gpt-4o
 label: gpt-4o
 model_type: chat
 features:
-  - tool_call
-  - agent_thought
-  - image_input
+- tool_call
+- agent_thought
+- image_input
 context_window: 128000
 max_output_tokens: 16384
 attributes:
   model: gpt-4o
 parameters:
-  - name: temperature
-    use_template: temperature
-  - name: top_p
-    use_template: top_p
-  - name: presence_penalty
-    use_template: presence_penalty
-  - name: frequency_penalty
-    use_template: frequency_penalty
-  - name: max_tokens
-    use_template: max_tokens
-    default: 4096
+- name: temperature
+  use_template: temperature
+- name: top_p
+  use_template: top_p
+- name: presence_penalty
+  use_template: presence_penalty
+- name: frequency_penalty
+  use_template: frequency_penalty
+- name: max_tokens
+  use_template: max_tokens
+  default: 4096
 metadata:
   pricing:
-    input: 0.0025
-    output: 0.01
+    input: 0.017097
+    output: 0.068386
     unit: 0.001
-    currency: USD
+    currency: RMB
   pricing_cache_hit:
-    input: 0.00125
-    output: 0.01
+    input: 0.008548
+    output: 0.068386
     unit: 0.001
-    currency: USD
+    currency: RMB

--- a/api/internal/core/language_model/providers/openai/gpt-5.2-mini.yaml
+++ b/api/internal/core/language_model/providers/openai/gpt-5.2-mini.yaml
@@ -2,32 +2,32 @@ model: gpt-5.2-mini
 label: gpt-5.2-mini
 model_type: chat
 features:
-  - tool_call
-  - agent_thought
-  - image_input
+- tool_call
+- agent_thought
+- image_input
 context_window: 400000
 max_output_tokens: 128000
 attributes:
   model: gpt-5.2-mini
 parameters:
-  - name: temperature
-    use_template: temperature
-    default: 1
-  - name: top_p
-    use_template: top_p
-    default: 1
-  - name: max_tokens
-    use_template: max_tokens
-    default: 8192
-    max: 128000
+- name: temperature
+  use_template: temperature
+  default: 1
+- name: top_p
+  use_template: top_p
+  default: 1
+- name: max_tokens
+  use_template: max_tokens
+  default: 8192
+  max: 128000
 metadata:
   pricing:
-    input: 0.0004
-    output: 0.0016
+    input: 0.002735
+    output: 0.010942
     unit: 0.001
-    currency: USD
+    currency: RMB
   pricing_cache_hit:
-    input: 0.0001
-    output: 0.0016
+    input: 0.000684
+    output: 0.010942
     unit: 0.001
-    currency: USD
+    currency: RMB

--- a/api/internal/core/language_model/providers/openai/gpt-5.2-nano.yaml
+++ b/api/internal/core/language_model/providers/openai/gpt-5.2-nano.yaml
@@ -2,32 +2,32 @@ model: gpt-5.2-nano
 label: gpt-5.2-nano
 model_type: chat
 features:
-  - tool_call
-  - agent_thought
-  - image_input
+- tool_call
+- agent_thought
+- image_input
 context_window: 400000
 max_output_tokens: 128000
 attributes:
   model: gpt-5.2-nano
 parameters:
-  - name: temperature
-    use_template: temperature
-    default: 1
-  - name: top_p
-    use_template: top_p
-    default: 1
-  - name: max_tokens
-    use_template: max_tokens
-    default: 8192
-    max: 128000
+- name: temperature
+  use_template: temperature
+  default: 1
+- name: top_p
+  use_template: top_p
+  default: 1
+- name: max_tokens
+  use_template: max_tokens
+  default: 8192
+  max: 128000
 metadata:
   pricing:
-    input: 0.0001
-    output: 0.0004
+    input: 0.000684
+    output: 0.002735
     unit: 0.001
-    currency: USD
+    currency: RMB
   pricing_cache_hit:
-    input: 0.000025
-    output: 0.0004
+    input: 0.000171
+    output: 0.002735
     unit: 0.001
-    currency: USD
+    currency: RMB

--- a/api/internal/core/language_model/providers/openai/gpt-5.2-pro.yaml
+++ b/api/internal/core/language_model/providers/openai/gpt-5.2-pro.yaml
@@ -2,21 +2,21 @@ model: gpt-5.2-pro
 label: gpt-5.2-pro
 model_type: chat
 features:
-  - tool_call
-  - agent_thought
-  - image_input
+- tool_call
+- agent_thought
+- image_input
 context_window: 400000
 max_output_tokens: 128000
 attributes:
   model: gpt-5.2-pro
 parameters:
-  - name: max_tokens
-    use_template: max_tokens
-    default: 8192
-    max: 128000
+- name: max_tokens
+  use_template: max_tokens
+  default: 8192
+  max: 128000
 metadata:
   pricing:
-    input: 0.02
-    output: 0.08
+    input: 0.136772
+    output: 0.547089
     unit: 0.001
-    currency: USD
+    currency: RMB

--- a/api/internal/core/language_model/providers/openai/gpt-5.2.yaml
+++ b/api/internal/core/language_model/providers/openai/gpt-5.2.yaml
@@ -2,32 +2,32 @@ model: gpt-5.2
 label: gpt-5.2
 model_type: chat
 features:
-  - tool_call
-  - agent_thought
-  - image_input
+- tool_call
+- agent_thought
+- image_input
 context_window: 400000
 max_output_tokens: 128000
 attributes:
   model: gpt-5.2
 parameters:
-  - name: temperature
-    use_template: temperature
-    default: 1
-  - name: top_p
-    use_template: top_p
-    default: 1
-  - name: max_tokens
-    use_template: max_tokens
-    default: 8192
-    max: 128000
+- name: temperature
+  use_template: temperature
+  default: 1
+- name: top_p
+  use_template: top_p
+  default: 1
+- name: max_tokens
+  use_template: max_tokens
+  default: 8192
+  max: 128000
 metadata:
   pricing:
-    input: 0.002
-    output: 0.008
+    input: 0.013677
+    output: 0.054709
     unit: 0.001
-    currency: USD
+    currency: RMB
   pricing_cache_hit:
-    input: 0.0005
-    output: 0.008
+    input: 0.003419
+    output: 0.054709
     unit: 0.001
-    currency: USD
+    currency: RMB

--- a/api/internal/core/language_model/providers/zhipu/glm-4.7-flash.yaml
+++ b/api/internal/core/language_model/providers/zhipu/glm-4.7-flash.yaml
@@ -2,27 +2,27 @@ model: glm-4.7-flash
 label: glm-4.7-flash
 model_type: chat
 features:
-  - tool_call
-  - agent_thought
+- tool_call
+- agent_thought
 context_window: 8000
 max_output_tokens: 16000
 attributes:
   model: glm-4.7-flash
 parameters:
-  - name: temperature
-    use_template: temperature
-    default: 0.7
-  - name: top_p
-    use_template: top_p
-    default: 0.7
-  - name: max_tokens
-    use_template: max_tokens
-    default: 4096
-    max: 16000
+- name: temperature
+  use_template: temperature
+  default: 0.7
+- name: top_p
+  use_template: top_p
+  default: 0.7
+- name: max_tokens
+  use_template: max_tokens
+  default: 4096
+  max: 16000
 metadata:
   pricing:
     input: 0.0
     output: 0.0
     unit: 0.001
-    currency: USD
+    currency: RMB
   pricing_note: 官方价格页标注该模型为免费模型。

--- a/api/internal/core/language_model/providers/zhipu/glm-4.7.yaml
+++ b/api/internal/core/language_model/providers/zhipu/glm-4.7.yaml
@@ -2,26 +2,26 @@ model: glm-4.7
 label: glm-4.7
 model_type: chat
 features:
-  - tool_call
-  - agent_thought
+- tool_call
+- agent_thought
 context_window: 200000
 max_output_tokens: 96000
 attributes:
   model: glm-4.7
 parameters:
-  - name: temperature
-    use_template: temperature
-    default: 0.7
-  - name: top_p
-    use_template: top_p
-    default: 0.7
-  - name: max_tokens
-    use_template: max_tokens
-    default: 8192
-    max: 96000
+- name: temperature
+  use_template: temperature
+  default: 0.7
+- name: top_p
+  use_template: top_p
+  default: 0.7
+- name: max_tokens
+  use_template: max_tokens
+  default: 8192
+  max: 96000
 metadata:
   pricing:
-    input: 0.0003
-    output: 0.0012
+    input: 0.002052
+    output: 0.008206
     unit: 0.001
-    currency: USD
+    currency: RMB

--- a/api/internal/core/language_model/providers/zhipu/glm-5.yaml
+++ b/api/internal/core/language_model/providers/zhipu/glm-5.yaml
@@ -2,26 +2,26 @@ model: glm-5
 label: glm-5
 model_type: chat
 features:
-  - tool_call
-  - agent_thought
+- tool_call
+- agent_thought
 context_window: 200000
 max_output_tokens: 128000
 attributes:
   model: glm-5
 parameters:
-  - name: temperature
-    use_template: temperature
-    default: 0.7
-  - name: top_p
-    use_template: top_p
-    default: 0.7
-  - name: max_tokens
-    use_template: max_tokens
-    default: 8192
-    max: 128000
+- name: temperature
+  use_template: temperature
+  default: 0.7
+- name: top_p
+  use_template: top_p
+  default: 0.7
+- name: max_tokens
+  use_template: max_tokens
+  default: 8192
+  max: 128000
 metadata:
   pricing:
-    input: 0.0006
-    output: 0.0022
+    input: 0.004103
+    output: 0.015045
     unit: 0.001
-    currency: USD
+    currency: RMB

--- a/api/test/internal/core/language_model/test_language_model_core.py
+++ b/api/test/internal/core/language_model/test_language_model_core.py
@@ -188,6 +188,85 @@ def test_deepseek_provider_should_expose_latest_models(monkeypatch):
     assert pro.attributes["model"] == "deepseek-v4-pro"
 
 
+def test_provider_pricing_should_be_rmb_across_all_models():
+    repo_root = Path(__file__).resolve().parents[5]
+    providers_root = repo_root / "api/internal/core/language_model/providers"
+
+    def assert_all_currency_fields_are_rmb(node, rel_path: str):
+        if isinstance(node, dict):
+            if "currency" in node:
+                assert node["currency"] == "RMB", f"{rel_path} has non-RMB currency {node['currency']}"
+            for key, value in node.items():
+                assert_all_currency_fields_are_rmb(value, f"{rel_path}.{key}")
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                assert_all_currency_fields_are_rmb(value, f"{rel_path}[{index}]")
+
+    for yaml_path in providers_root.rglob("*.yaml"):
+        if yaml_path.name in {"providers.yaml", "positions.yaml"}:
+            continue
+
+        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            continue
+
+        metadata = data.get("metadata")
+        if isinstance(metadata, dict):
+            assert_all_currency_fields_are_rmb(
+                metadata, yaml_path.relative_to(providers_root).as_posix()
+            )
+
+    deepseek_v4_pro = yaml.safe_load(
+        (providers_root / "deepseek/deepseek-v4-pro.yaml").read_text(encoding="utf-8")
+    )
+    assert deepseek_v4_pro["metadata"]["pricing"]["currency"] == "RMB"
+    assert deepseek_v4_pro["metadata"]["pricing"]["input"] == pytest.approx(0.000992)
+    assert deepseek_v4_pro["metadata"]["pricing"]["output"] == pytest.approx(0.00595)
+    assert deepseek_v4_pro["metadata"]["pricing_cache_hit"]["input"] == pytest.approx(
+        0.000248
+    )
+    assert deepseek_v4_pro["metadata"]["pricing_cache_hit"]["output"] == pytest.approx(
+        0.00595
+    )
+
+    gemini_pro = yaml.safe_load(
+        (providers_root / "google/gemini-2.5-pro.yaml").read_text(encoding="utf-8")
+    )
+    assert gemini_pro["metadata"]["pricing"]["currency"] == "RMB"
+    assert gemini_pro["metadata"]["pricing"]["input"] == pytest.approx(0.008548)
+    assert gemini_pro["metadata"]["pricing"]["output"] == pytest.approx(0.068386)
+    assert gemini_pro["metadata"]["pricing_tiered"]["long_context"]["currency"] == "RMB"
+    assert gemini_pro["metadata"]["pricing_tiered"]["long_context"]["input"] == pytest.approx(
+        0.017097
+    )
+    assert gemini_pro["metadata"]["pricing_tiered"]["long_context"]["output"] == pytest.approx(
+        0.102579
+    )
+
+    grok_4 = yaml.safe_load((providers_root / "grok/grok-4.yaml").read_text(encoding="utf-8"))
+    assert grok_4["metadata"]["pricing"]["currency"] == "RMB"
+    assert grok_4["metadata"]["pricing"]["input"] == pytest.approx(0.020516)
+    assert grok_4["metadata"]["pricing"]["output"] == pytest.approx(0.102579)
+    assert grok_4["metadata"]["pricing_long_context"]["currency"] == "RMB"
+    assert grok_4["metadata"]["pricing_long_context"]["input"] == pytest.approx(0.041032)
+    assert grok_4["metadata"]["pricing_long_context"]["output"] == pytest.approx(0.205158)
+    assert grok_4["metadata"]["pricing_cache_hit"]["currency"] == "RMB"
+    assert grok_4["metadata"]["pricing_cache_hit"]["input"] == pytest.approx(0.005129)
+    assert grok_4["metadata"]["pricing_cache_hit"]["output"] == pytest.approx(0.102579)
+
+    gpt_5_2_pro = yaml.safe_load(
+        (providers_root / "openai/gpt-5.2-pro.yaml").read_text(encoding="utf-8")
+    )
+    assert gpt_5_2_pro["metadata"]["pricing"]["currency"] == "RMB"
+    assert gpt_5_2_pro["metadata"]["pricing"]["input"] == pytest.approx(0.136772)
+    assert gpt_5_2_pro["metadata"]["pricing"]["output"] == pytest.approx(0.547089)
+
+    glm_5 = yaml.safe_load((providers_root / "zhipu/glm-5.yaml").read_text(encoding="utf-8"))
+    assert glm_5["metadata"]["pricing"]["currency"] == "RMB"
+    assert glm_5["metadata"]["pricing"]["input"] == pytest.approx(0.004103)
+    assert glm_5["metadata"]["pricing"]["output"] == pytest.approx(0.015045)
+
+
 def test_language_model_manager_should_load_and_delegate(monkeypatch, tmp_path):
     providers_dir = tmp_path / "providers"
     providers_dir.mkdir()


### PR DESCRIPTION
Normalize all provider model pricing metadata under `api/internal/core/language_model/providers` to RMB and convert USD price values using a fixed USD/CNY rate. Includes a regression test to ensure all provider metadata currencies stay RMB.